### PR TITLE
Experimentally optimize index array representation

### DIFF
--- a/Sources/GIF/Lzw/LzwDecoder.swift
+++ b/Sources/GIF/Lzw/LzwDecoder.swift
@@ -42,14 +42,17 @@ struct LzwDecoder {
                 log.trace("Found code: k = \(k) from \(indices) @ codeSize \(table.meta.codeSize)")
                 if let lastCode = lastCode {
                     guard let lastIndices = table[lastCode] else { throw LzwCodingError.tableTooSmall }
-                    table.append(indices: lastIndices + [k])
+                    var nextIndices = lastIndices
+                    nextIndices.append(k)
+                    table.append(indices: nextIndices)
                 }
             } else {
                 guard let lastCode = lastCode else { throw LzwCodingError.noLastCode }
                 guard let lastIndices = table[lastCode] else { throw LzwCodingError.tableTooSmall }
                 guard let k = lastIndices.first else { throw LzwCodingError.decodedIndicesEmpty }
                 log.trace("Did not found code: k = \(k)")
-                let nextIndices = lastIndices + [k]
+                var nextIndices = lastIndices
+                nextIndices.append(k)
                 decoded.append(contentsOf: nextIndices)
                 table.append(indices: nextIndices)
             }

--- a/Sources/GIF/Lzw/LzwDecoderTable.swift
+++ b/Sources/GIF/Lzw/LzwDecoderTable.swift
@@ -6,7 +6,7 @@ fileprivate let log = Logger(label: "GIF.LzwDecoderTable")
 
 struct LzwDecoderTable: CustomStringConvertible {
     // Stores the mappings from single codes to multiple indices
-    private(set) var entries: [Int: [Int]] = [:]
+    private(set) var entries: [Int: IndexArray] = [:]
 	public var meta: LzwTableMeta
 	public var description: String { "\(entries)" }
 
@@ -14,15 +14,15 @@ struct LzwDecoderTable: CustomStringConvertible {
         meta = LzwTableMeta(colorCount: colorCount, minCodeSize: minCodeSize)
     }
 
-    public subscript(_ code: Int) -> [Int]? {
+    public subscript(_ code: Int) -> IndexArray? {
         if code < meta.minCount {
-            return [code]
+            return .init(code)
         } else {
             return entries[code]
         }
     }
 
-    public mutating func append(indices: [Int]) {
+    public mutating func append(indices: IndexArray) {
         entries[meta.count] = indices
         log.trace("Added \(meta.count)")
         meta.incrementCount()

--- a/Sources/GIF/Lzw/LzwEncoder.swift
+++ b/Sources/GIF/Lzw/LzwEncoder.swift
@@ -7,7 +7,7 @@ fileprivate let maxCodeTableCount: Int = (1 << 12) - 1
 
 struct LzwEncoder {
     private(set) var table: LzwEncoderTable
-    private var indexBuffer: [Int] = []
+    private var indexBuffer: IndexArray = .init()
 
     public var minCodeSize: Int { table.meta.minCodeSize }
 
@@ -21,7 +21,8 @@ struct LzwEncoder {
 
     public mutating func encodeAndAppend(index: Int, into data: inout BitData) {
         // The main LZW encoding algorithm
-        let extendedBuffer = indexBuffer + [index]
+        var extendedBuffer = indexBuffer
+        extendedBuffer.append(index)
         if table.contains(indices: extendedBuffer) {
             indexBuffer = extendedBuffer
         } else {
@@ -32,7 +33,7 @@ struct LzwEncoder {
             } else {
                 table.append(indices: extendedBuffer)
             }
-            indexBuffer = [index]
+            indexBuffer = .init(index)
         }
     }
 

--- a/Sources/GIF/Lzw/LzwEncoderTable.swift
+++ b/Sources/GIF/Lzw/LzwEncoderTable.swift
@@ -5,7 +5,7 @@ fileprivate let log = Logger(label: "GIF.LzwEncoderTable")
 
 struct LzwEncoderTable: CustomStringConvertible {
     // Stores the mapping from multiple indices to a single code
-    private var entries: [[Int]: Int] = [:]
+    private var entries: [IndexArray: Int] = [:]
     public var meta: LzwTableMeta
     public var description: String { "\(entries)" }
 
@@ -13,7 +13,7 @@ struct LzwEncoderTable: CustomStringConvertible {
         meta = LzwTableMeta(colorCount: colorCount)
     }
 
-    public subscript(indices: [Int]) -> Int? {
+    public subscript(indices: IndexArray) -> Int? {
         if indices.count == 1 {
             // A single index matches its color code
             return indices.first
@@ -22,7 +22,7 @@ struct LzwEncoderTable: CustomStringConvertible {
         }
     }
 
-    public mutating func append(indices: [Int]) {
+    public mutating func append(indices: IndexArray) {
         assert(indices.count > 1)
         entries[indices] = meta.count
         log.trace("Added \(meta.count)")
@@ -30,7 +30,7 @@ struct LzwEncoderTable: CustomStringConvertible {
         meta.updateCodeSize(offset: 1)
     }
 
-    public func contains(indices: [Int]) -> Bool {
+    public func contains(indices: IndexArray) -> Bool {
         return self[indices] != nil
     }
 

--- a/Sources/GIF/Utils/IndexArray.swift
+++ b/Sources/GIF/Utils/IndexArray.swift
@@ -1,0 +1,36 @@
+struct IndexArray: Hashable {
+    private var entries: [Entry]
+    private(set) var count: Int
+
+    struct Entry: Hashable {
+        var value: Int
+        var count: Int = 1
+    }
+
+    var first: Int? {
+        entries.first?.value
+    }
+
+    var last: Int? {
+        entries.last?.value
+    }
+
+    init() {
+        entries = []
+        count = 0
+    }
+
+    init(_ value: Int) {
+        entries = [.init(value: value)]
+        count = 1
+    }
+
+    mutating func append(_ value: Int) {
+        if value == entries.last?.value {
+            entries[entries.count - 1].count += 1
+        } else {
+            entries.append(.init(value: value))
+        }
+        count += 1
+    }
+}

--- a/Sources/GIF/Utils/IndexArray.swift
+++ b/Sources/GIF/Utils/IndexArray.swift
@@ -1,4 +1,6 @@
-struct IndexArray: Hashable {
+struct IndexArray: Hashable, Sequence {
+    typealias Element = Int
+
     private var entries: [Entry]
     private(set) var count: Int
 
@@ -32,5 +34,46 @@ struct IndexArray: Hashable {
             entries.append(.init(value: value))
         }
         count += 1
+    }
+
+    mutating func append(contentsOf array: IndexArray) {
+        if let lastEntry = entries.last, let firstEntry = array.entries.first, lastEntry.value == firstEntry.value {
+            entries[entries.count - 1].count += firstEntry.count
+            entries += array.entries.dropFirst()
+        } else {
+            entries += array.entries
+        }
+    }
+
+    func makeIterator() -> Iterator {
+        Iterator(self)
+    }
+
+    struct Iterator: IteratorProtocol {
+        private let array: IndexArray
+        private var entryIndex = 0
+        private var valueIndex = 0
+
+        private var entry: Entry {
+            array.entries[entryIndex]
+        }
+
+        fileprivate init(_ array: IndexArray) {
+            self.array = array
+        }
+
+        mutating func next() -> Element? {
+            guard entryIndex < array.entries.count else {
+                return nil
+            }
+            let value = entry.value
+            if valueIndex >= entry.count - 1 {
+                valueIndex = 0
+                entryIndex += 1
+            } else {
+                valueIndex += 1
+            }
+            return value
+        }
     }
 }

--- a/Tests/GIFTests/Utils/IndexArrayTests.swift
+++ b/Tests/GIFTests/Utils/IndexArrayTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+@testable import GIF
+
+final class IndexArrayTests: XCTestCase {
+    func testIndexArray() {
+        XCTAssertEqual(Array(IndexArray()), [])
+        XCTAssertEqual(Array(IndexArray(42)), [42])
+
+        var array = IndexArray()
+        array.append(2)
+        array.append(3)
+        array.append(3)
+        array.append(50)
+        array.append(50)
+        array.append(50)
+        array.append(2)
+        XCTAssertEqual(Array(array), [2, 3, 3, 50, 50, 50, 2])
+    }
+}


### PR DESCRIPTION
This swaps out the LZW tables internal index array representation for a "compressed" one, in an attempt to save memory and time. Might require some more profiling though.